### PR TITLE
Add Status Code to OneWayError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2020-05-29
+
+### Added
+
+- Status code for `OneWayError`.
+
+### Updated
+
+- Tests to include request failure assertion.
+
 ## [0.1.0] - 2020-05-25
 
 - Initial release

--- a/_mock_server.ts
+++ b/_mock_server.ts
@@ -2,6 +2,7 @@
 import {
   listenAndServe,
   ServerRequest,
+  Status,
 } from "https://deno.land/std/http/mod.ts";
 import { decode } from "https://deno.land/std/node/querystring.ts";
 import { HOSTNAME, PORT } from "./_mock_config.ts";
@@ -52,6 +53,10 @@ listenAndServe(
       }
       if (message === "unknown error") {
         req.respond({ body: "random" });
+        return;
+      }
+      if (message === "request failure") {
+        req.respond({ status: Status.InternalServerError });
         return;
       }
       if (mobileno === "60123456789,60129876543") {

--- a/error.ts
+++ b/error.ts
@@ -1,4 +1,8 @@
 // Copyright 2020 KwanJunWen. All rights reserved. MIT license.
+import {
+  Status,
+  STATUS_TEXT,
+} from "https://deno.land/std/http/mod.ts";
 /**
  * OneWay specific error. Switch based on code to handle specific error
  * when using OneWayClient.
@@ -20,9 +24,12 @@
  */
 export class OneWayError extends Error {
   readonly code: OneWayErrorType;
+  readonly statusCode: Status;
 
-  constructor(message: string, code: OneWayErrorType) {
-    super(message);
+  constructor(message: string, code: OneWayErrorType, statusCode?: Status) {
+    const _statusCode = statusCode || Status.OK;
+    super(`${statusCode} (${STATUS_TEXT.get(_statusCode)}): ${message}`);
+    this.statusCode = _statusCode;
     this.name = "OneWayError";
     this.code = code;
   }

--- a/oneway.ts
+++ b/oneway.ts
@@ -161,9 +161,9 @@ export class OneWay implements OneWayClient {
               new OneWayError(
                 "request failure",
                 OneWayErrorType.RequestFailure,
+                resp.status,
               ),
             );
-            return "";
           }
           return resp.text();
         }).then((respText: string): void => {

--- a/oneway_test.ts
+++ b/oneway_test.ts
@@ -1,4 +1,5 @@
 // Copyright 2020 KwanJunWen. All rights reserved. MIT license.
+import { Status } from "https://deno.land/std/http/mod.ts";
 import { assertEquals, assert } from "https://deno.land/std/testing/asserts.ts";
 import { OneWay } from "./oneway.ts";
 import {
@@ -41,6 +42,31 @@ Deno.test("OneWay:sendSMS -> With multiple mobileNo", async () => {
     assertEquals(data.mtIDs, [145712468, 145712469]);
   } catch (err) {
     assert(!err);
+  }
+});
+
+Deno.test("OneWay:sendSMS -> With request failure", async () => {
+  const svc = new OneWay({
+    baseURL: `http://${HOSTNAME}:${PORT}`,
+    apiUsername: "Username",
+    apiPassword: "Password",
+    senderID: "SenderID",
+  });
+  try {
+    const data = await svc.sendSMS({
+      message: "request failure",
+      mobileNo: "60123456789",
+    });
+    assert(!data.mtIDs);
+  } catch (err) {
+    assertEquals(
+      err,
+      new OneWayError(
+        "request failure",
+        OneWayErrorType.RequestFailure,
+        Status.InternalServerError,
+      ),
+    );
   }
 });
 


### PR DESCRIPTION
## [0.1.1] - 2020-05-29

### Added

- Status code for `OneWayError`.

### Updated

- Tests to include request failure assertion.
- README.md URL example when importing module.